### PR TITLE
tidyr new version compatibility fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureKusto
 Title: Interface to 'Kusto'/'Azure Data Explorer'
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi@microsoft.com", role = c("aut", "cre")),
     person("Alex", "Kyllo", , "jekyllo@microsoft.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# AzureKusto 1.0.3
+
+* Compatibility update for tidyr 1.0.
+
 # AzureKusto 1.0.2
 
 * Implement `nest` and `unnest` verbs.

--- a/R/kql-build.R
+++ b/R/kql-build.R
@@ -298,7 +298,7 @@ flatten_query <- function(op, ops=list())
     if (is_empty(ops))
         new_ops <- list(flat_op)
     else
-        new_ops <- prepend(ops, list(flat_op))
+        new_ops <- c(list(flat_op), ops)
     if (inherits(op, "op_base"))
         return(new_ops)
     else

--- a/R/ops.R
+++ b/R/ops.R
@@ -152,7 +152,7 @@ add_suffixes <- function(x, y, suffix)
 {
     if (identical(suffix, "")) return(x)
 
-    out <- chr_along(x)
+    out <- rep_len(na_chr, length(x))
     for (i in seq_along(x))
     {
         nm <- x[[i]]
@@ -244,7 +244,7 @@ op_vars.op_select <- function(op)
 #' @export
 op_vars.op_rename <- function(op)
 {
-    names(rename_vars(op_vars(op$x), !!! op$dots))
+    names(tidyselect::vars_rename(op_vars(op$x), !!! op$dots))
 }
 
 #' @export


### PR DESCRIPTION
Since our package implements tidyr::nest and unnest as methods of tbl, and these have breaking changes, some tests need to be conditioned on tidyr package version.

Also removing some rlang functions that have deprecation warnings in v 0.4.0. 