### PR TITLE
Replace "weakconsistency" with "strongconsistency"

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -79,7 +79,7 @@ build_param_list <- function(query_params)
 build_request_body <- function(db, qry_cmd, query_options=list(), query_parameters=list())
 {
     default_query_options <- list(
-        queryconsistency="weakconsistency",
+        queryconsistency="strongconsistency",
         response_dynamic_serialization="string",
         response_dynamic_serialization_2="legacy")
 


### PR DESCRIPTION
Replace "weakconsistency" with "strongconsistency" in the default query options, because per the Kusto team, weakconsistency should only be used if absolutely necessary, and it can cause query errors under certain cluster configurations.