### PR TITLE
Enable basic auth (closes #6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureKusto
 Title: Interface to 'Kusto'/'Azure Data Explorer'
-Version: 1.0.3
+Version: 1.0.3.9000
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi@microsoft.com", role = c("aut", "cre")),
     person("Alex", "Kyllo", , "jekyllo@microsoft.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# AzureKusto 1.0.3.9000
+
+* Change default query consistency setting to `strong`.
+* Enable basic authentication (username & password) for signing in to an endpoint. This is not recommended, but necessary for some connections. To use basic auth, supply the `user` and `pwd` properties to `kusto_database_endpoint` and set the `.query_token` argument to `FALSE`.
+
 # AzureKusto 1.0.3
 
 * Compatibility update for tidyr 1.0.

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -28,11 +28,11 @@
 #' @examples
 #' \dontrun{
 #'
-#' get_kusto_token("myclust.australiaeast.kusto.windows.net")
-#' get_kusto_token(clustername="myclust", location="australiaeast")
+#' get_kusto_token("https://myclust.westus.kusto.windows.net")
+#' get_kusto_token(clustername="myclust", location="westus")
 #'
 #' # authenticate using client_credentials method: see ?AzureAuth::get_azure_token
-#' get_kusto_token("myclust.australiaeast.kusto.windows.net",
+#' get_kusto_token("https://myclust.westus.kusto.windows.net",
 #'                 tenant="mytenant", app="myapp", password="password")
 #'
 #' }

--- a/R/query.R
+++ b/R/query.R
@@ -21,7 +21,7 @@
 #' @examples
 #' \dontrun{
 #'
-#' endp <- kusto_database_endpoint(server="myclust.australiaeast.kusto.windows.net", database="db1")
+#' endp <- kusto_database_endpoint(server="https://myclust.westus.kusto.windows.net", database="db1")
 #'
 #' # a command
 #' run_query(endp, ".show table iris")
@@ -108,10 +108,8 @@ build_request_body <- function(db, qry_cmd, query_options=list(), query_paramete
 
 build_auth_str <- function(token=NULL, user=NULL, password=NULL)
 {
-    token <- validate_token(token)
-
     auth_str <- if(!is.null(token))
-        paste("Bearer", token)
+        paste("Bearer", validate_token(token))
     else if(!is.null(user) && !is.null(password))
         paste("Basic", openssl::base64_encode(paste(user, password, sep=":")))
     else stop("Must provide authentication details")

--- a/man/database_endpoint.Rd
+++ b/man/database_endpoint.Rd
@@ -83,11 +83,11 @@ App authentication properties:
 }
 }
 
-Currently, AzureKusto only supports authentication via Azure Active Directory. Authenticating with DSTS is planned for the future.
+Currently, AzureKusto supports authentication via an Azure Active Directory OAuth token, or with basic authentication (a username and password). The latter is not recommended, but may be necessary for certain connections.
 
-The way \code{kusto_database_endpoint} obtains an AAD token is as follows.
+To use basic authentication, supply the \code{user} and \code{pwd} properties, and set the \code{.query_token} argument to FALSE. Otherwise, \code{kusto_database_endpoint} will use AAD authentication, obtaining a token via the following procedure.
 \enumerate{
-\item If the \code{.query_token} argument is supplied, use it.
+\item If the \code{.query_token} argument is supplied and not FALSE, use it.
 \item Otherwise, if the \code{usertoken} property is supplied, use it.
 \item Otherwise, if the \code{apptoken} property is supplied, use it.
 \item Otherwise, if the \code{appclientid} property is supplied, use it to obtain a token:
@@ -106,13 +106,16 @@ The way \code{kusto_database_endpoint} obtains an AAD token is as follows.
 \examples{
 \dontrun{
 
-kusto_database_endpoint(server="myclust.australiaeast.kusto.windows.net", database="db1")
+kusto_database_endpoint(server="https://myclust.westus.kusto.windows.net", database="db1")
 
 # supplying a token obtained previously
-token <- get_kusto_token("myclust.australiaeast.kusto.windows.net")
-kusto_database_endpoint(server="myclust.australiaeast.kusto.windows.net", database="db1",
+token <- get_kusto_token("https://myclust.westus.kusto.windows.net")
+kusto_database_endpoint(server="https://myclust.westus.kusto.windows.net", database="db1",
                         .query_token=token)
 
+# basic (username/password) authentication
+kusto_database_endpoint(server="https://myclust.westus.kusto.windows.net", database="db1",
+                        user="myname", pwd="mypassword", .query_token=FALSE)
 }
 }
 \seealso{

--- a/man/get_kusto_token.Rd
+++ b/man/get_kusto_token.Rd
@@ -48,11 +48,11 @@ By default, authentication tokens will be obtained using the main KustoClient Ac
 \examples{
 \dontrun{
 
-get_kusto_token("myclust.australiaeast.kusto.windows.net")
-get_kusto_token(clustername="myclust", location="australiaeast")
+get_kusto_token("https://myclust.westus.kusto.windows.net")
+get_kusto_token(clustername="myclust", location="westus")
 
 # authenticate using client_credentials method: see ?AzureAuth::get_azure_token
-get_kusto_token("myclust.australiaeast.kusto.windows.net",
+get_kusto_token("https://myclust.westus.kusto.windows.net",
                 tenant="mytenant", app="myapp", password="password")
 
 }

--- a/man/run_query.Rd
+++ b/man/run_query.Rd
@@ -24,7 +24,7 @@ This function is the workhorse of the AzureKusto package. It communicates with t
 \examples{
 \dontrun{
 
-endp <- kusto_database_endpoint(server="myclust.australiaeast.kusto.windows.net", database="db1")
+endp <- kusto_database_endpoint(server="https://myclust.westus.kusto.windows.net", database="db1")
 
 # a command
 run_query(endp, ".show table iris")


### PR DESCRIPTION
To use basic auth, supply `user` and `pwd` to `kusto_database_endpoint` and set `.query_token` to FALSE:

```r
kusto_database_endpoint(server="server", database="db", user="myname", pwd="mypasswd",
    .query_token=FALSE)
```