### PR TITLE
Default to AAD v2 for `get_kusto_token`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureKusto
 Title: Interface to 'Kusto'/'Azure Data Explorer'
-Version: 1.0.6
+Version: 1.0.6.9000
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = "aut"),
     person("Alex", "Kyllo", , "jekyllo@microsoft.com", role = c("aut", "cre")),
@@ -37,5 +37,5 @@ Suggests:
     AzureGraph,
     AzureStor (>= 2.0.0),
     rmarkdown
-Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.1.0
+Roxygen: list(markdown=TRUE, r6=FALSE)
+RoxygenNote: 7.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# AzureKusto 1.0.6.9000
+
+* Switch to AAD v2 when obtaining OAuth tokens with `get_kusto_token`.
+
 # AzureKusto 1.0.6
 
 * Compatibility update for dplyr 1.0.0.

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -94,9 +94,6 @@ kusto_database_endpoint <- function(..., .connection_string=NULL, .query_token=N
     props <- normalize_connstring_properties(props)
 
     props$token <- find_endpoint_token(props, .query_token)
-    if(AzureRMR::is_azure_token(props$token) && props$token$credentials$resource != props$server)
-        warning(sprintf("Mismatch between server (%s) and token resource (%s)",
-                        props$token$credentials$resource, props$server))
 
     props$use_integer64 <- .use_integer64
     props <- check_endpoint_properties(props)

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -53,7 +53,7 @@ get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL
     }
 
     if(version == 2 && httr::parse_url(server)$path == "")
-        server <- paste0(sub("/$", "", server), "/.default")
+        server <- c(paste0(sub("/$", "", server), "/.default"), "offline_access", "openid")
 
     # KustoClient requires devicecode auth if username not supplied
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))
@@ -84,7 +84,7 @@ delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=N
     }
 
     if(version == 2 && httr::parse_url(server)$path == "")
-        server <- paste0(sub("/$", "", server), "/.default")
+        server <- c(paste0(sub("/$", "", server), "/.default"), "offline_access", "openid")
 
     # KustoClient requires devicecode auth if username not supplied
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -59,7 +59,7 @@ get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))
         auth_type <- "device_code"
 
-    AzureAuth::get_azure_token(server, tenant, app, auth_type=auth_type, ...)
+    AzureAuth::get_azure_token(server, tenant, app, auth_type=auth_type, version=version, ...)
 }
 
 
@@ -90,7 +90,7 @@ delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=N
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))
         auth_type <- "device_code"
 
-    AzureAuth::delete_azure_token(server, tenant, app, auth_type=auth_type, confirm=confirm, ...)
+    AzureAuth::delete_azure_token(server, tenant, app, auth_type=auth_type, version=version, confirm=confirm, ...)
 }
 
 

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -10,6 +10,7 @@
 #' @param tenant Your Azure Active Directory (AAD) tenant. Can be a GUID, a name ("myaadtenant") or a fully qualified domain name ("myaadtenant.com").
 #' @param app The ID of the Azure Active Directory app/service principal to authenticate with. Defaults to the ID of the KustoClient app.
 #' @param auth_type The authentication method to use. Can be one of "authorization_code", "device_code", "client_credentials" or "resource_owner". The default is to pick one based on the other arguments.
+#' @param version The AAD version to use. There should be no reason to change this from the default value of 2.
 #' @param hash For `delete_kusto_token`, the MD5 hash of the token. This is used to identify the token if provided.
 #' @param confirm For `delete_kusto_token`, whether to ask for confirmation before deleting the token.
 #' @param ... Other arguments to pass to [AzureAuth::get_azure_token].
@@ -28,17 +29,17 @@
 #' @examples
 #' \dontrun{
 #'
-#' get_kusto_token("myclust.australiaeast.kusto.windows.net")
+#' get_kusto_token("https://myclust.australiaeast.kusto.windows.net")
 #' get_kusto_token(clustername="myclust", location="australiaeast")
 #'
 #' # authenticate using client_credentials method: see ?AzureAuth::get_azure_token
-#' get_kusto_token("myclust.australiaeast.kusto.windows.net",
+#' get_kusto_token("https://myclust.australiaeast.kusto.windows.net",
 #'                 tenant="mytenant", app="myapp", password="password")
 #'
 #' }
 #' @export
 get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL, app=.kusto_app_id, auth_type=NULL,
-                            ...)
+                            version=2, ...)
 {
     tenant <- if(is.null(tenant))
         "common"
@@ -51,6 +52,9 @@ get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL
         server <- paste0("https://", cluster, ".kusto.windows.net")
     }
 
+    if(version == 2 && httr::parse_url(server)$path == "")
+        server <- paste0(sub("/$", "", server), "/.default")
+
     # KustoClient requires devicecode auth if username not supplied
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))
         auth_type <- "device_code"
@@ -62,7 +66,7 @@ get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL
 #' @rdname get_kusto_token
 #' @export
 delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL, app=.kusto_app_id, auth_type=NULL,
-                               ..., hash=NULL, confirm=TRUE)
+                               version=2, ..., hash=NULL, confirm=TRUE)
 {
     # use hash if provided
     if(!is.null(hash))
@@ -78,6 +82,9 @@ delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=N
         cluster <- normalize_cluster(clustername, location)
         server <- paste0("https://", cluster, ".kusto.windows.net")
     }
+
+    if(version == 2 && httr::parse_url(server)$path == "")
+        server <- paste0(sub("/$", "", server), "/.default")
 
     # KustoClient requires devicecode auth if username not supplied
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))

--- a/man/get_kusto_token.Rd
+++ b/man/get_kusto_token.Rd
@@ -13,6 +13,7 @@ get_kusto_token(
   tenant = NULL,
   app = .kusto_app_id,
   auth_type = NULL,
+  version = 2,
   ...
 )
 
@@ -23,6 +24,7 @@ delete_kusto_token(
   tenant = NULL,
   app = .kusto_app_id,
   auth_type = NULL,
+  version = 2,
   ...,
   hash = NULL,
   confirm = TRUE
@@ -42,6 +44,8 @@ list_kusto_tokens()
 \item{app}{The ID of the Azure Active Directory app/service principal to authenticate with. Defaults to the ID of the KustoClient app.}
 
 \item{auth_type}{The authentication method to use. Can be one of "authorization_code", "device_code", "client_credentials" or "resource_owner". The default is to pick one based on the other arguments.}
+
+\item{version}{The AAD version to use. There should be no reason to change this from the default value of 2.}
 
 \item{...}{Other arguments to pass to \link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token}.}
 
@@ -63,11 +67,11 @@ By default, authentication tokens will be obtained using the main KustoClient Ac
 \examples{
 \dontrun{
 
-get_kusto_token("myclust.australiaeast.kusto.windows.net")
+get_kusto_token("https://myclust.australiaeast.kusto.windows.net")
 get_kusto_token(clustername="myclust", location="australiaeast")
 
 # authenticate using client_credentials method: see ?AzureAuth::get_azure_token
-get_kusto_token("myclust.australiaeast.kusto.windows.net",
+get_kusto_token("https://myclust.australiaeast.kusto.windows.net",
                 tenant="mytenant", app="myapp", password="password")
 
 }


### PR DESCRIPTION
This PR changes the default AAD version for `get_kusto_token` to v2. AAD v1 is now deprecated and MS recommends using v2 for everything. The underlying `AzureAuth::get_azure_token` function, which is called by `get_kusto_token`, currently defaults to v1 for backward compatibility reasons but will soon switch to v2 as well. This PR anticipates that change.

Assuming Kusto supports AAD v2 (and it would be crazy if it didn't), there should be no changes in functionality in AzureKusto.